### PR TITLE
[MIM-46] Home, Plan ViewModel 분리

### DIFF
--- a/presentation/src/main/java/com/moon/morningismiracle/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/home/HomeFragment.kt
@@ -19,7 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     override var layoutResourceId: Int = R.layout.fragment_home
 
-    private val viewModel: PlanViewModel by viewModels()
+    private val viewModel: HomeViewModel by viewModels()
     private val planAdapter = PlanRecyclerAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/presentation/src/main/java/com/moon/morningismiracle/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/home/HomeViewModel.kt
@@ -3,8 +3,14 @@ package com.moon.morningismiracle.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moon.domain.model.PlanModel
+import com.moon.domain.model.PlanState
 import com.moon.domain.usecase.GetPlanListUseCase
+import com.moon.domain.usecase.SetPlanDelayOneDayUseCase
+import com.moon.domain.usecase.SetPlanStateUseCase
+import com.moon.morningismiracle.di.DateInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
@@ -14,17 +20,33 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val getPlanListUseCase: GetPlanListUseCase
+    private val getPlanListUseCase: GetPlanListUseCase,
+    private val setPlanStateUseCase: SetPlanStateUseCase,
+    private val setPlanDelayOneDayUseCase: SetPlanDelayOneDayUseCase,
 ): ViewModel() {
 
     private val _planDataList = MutableStateFlow<List<PlanModel>>(emptyList())
     val planDataList: StateFlow<List<PlanModel>> = _planDataList
 
     fun getPlanList(date: Date) {
-        viewModelScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             getPlanListUseCase(date = date).collect { list ->
                 _planDataList.value = list
             }
+        }
+    }
+
+    fun setPlan(planId: Long, state: PlanState) {
+        CoroutineScope(Dispatchers.IO).launch {
+            setPlanStateUseCase(planId, state)
+            getPlanList(DateInfo.today)
+        }
+    }
+
+    fun setPlanDelayOndDay(planId: Long, newDate: Date) {
+        CoroutineScope(Dispatchers.IO).launch {
+            setPlanDelayOneDayUseCase(planId, newDate)
+            getPlanList(DateInfo.today)
         }
     }
 }

--- a/presentation/src/main/java/com/moon/morningismiracle/plan/PlanViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/plan/PlanViewModel.kt
@@ -1,11 +1,8 @@
 package com.moon.morningismiracle.plan
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.moon.domain.model.PlanModel
-import com.moon.domain.model.PlanState
 import com.moon.domain.usecase.*
-import com.moon.morningismiracle.di.DateInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -20,40 +17,23 @@ import javax.inject.Inject
 class PlanViewModel @Inject constructor(
     private val addPlanUseCase: AddPlanUseCase,
     private val deletePlanUseCase: DeletePlanUseCase,
-    private val setPlanStateBeforeToday: SetPlanStateBeforeToday,
     private val getPlanListUseCase: GetPlanListUseCase,
-    private val setPlanStateUseCase: SetPlanStateUseCase,
-    private val setPlanDelayOneDayUseCase: SetPlanDelayOneDayUseCase,
 ) : ViewModel() {
-
-    private var _planDataList = MutableStateFlow<List<PlanModel>>(emptyList())
-    val planDataList: StateFlow<List<PlanModel>> = _planDataList
 
     private var _selectDayPlanDataList = MutableStateFlow<List<PlanModel>>(emptyList())
     val selectDayPlanDataList: StateFlow<List<PlanModel>> = _selectDayPlanDataList
 
     fun addPlan(planData: PlanModel) {
-        viewModelScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             addPlanUseCase(planData)
+            getSelectDayPlanList(planData.planDate)
         }
     }
 
     fun deletePlan(planData: PlanModel, isSelectedDate: Boolean) {
-        viewModelScope.launch {
-            deletePlanUseCase(planData)
-            if (isSelectedDate) {
-                getSelectDayPlanList(planData.planDate)
-            } else {
-                getPlanList(planData.planDate)
-            }
-        }
-    }
-
-    fun getPlanList(date: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getPlanListUseCase(date = date).collect { list ->
-                _planDataList.value = list
-            }
+            deletePlanUseCase(planData)
+            getSelectDayPlanList(planData.planDate)
         }
     }
 
@@ -62,20 +42,6 @@ class PlanViewModel @Inject constructor(
             getPlanListUseCase(date = date).collect { list ->
                 _selectDayPlanDataList.value = list
             }
-        }
-    }
-
-    fun setPlan(planId: Long, state: PlanState) {
-        viewModelScope.launch {
-            setPlanStateUseCase(planId, state)
-            getPlanList(DateInfo.today)
-        }
-    }
-
-    fun setPlanDelayOndDay(planId: Long, newDate: Date) {
-        viewModelScope.launch {
-            setPlanDelayOneDayUseCase(planId, newDate)
-            getPlanList(DateInfo.today)
         }
     }
 }


### PR DESCRIPTION
Home, Plan ViewModel 분리

- 한 Fragment에서 이동한 후 다시 돌아갔을때 DispatchedTask에서 JobCancelEception이 발생해서
- viewModel을 분리하고, viewModelScope를 CoroutineScope(Dispatchers.IO)로 변경
- 수정후 정상동작하는데 아직 정확한 원인은 좀 더 공부를 해봐야할것같다