### PR TITLE
[MIM-56] TagDelete 기능에 Tag재조회 연결

### DIFF
--- a/presentation/src/main/java/com/moon/morningismiracle/tag/TagViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/tag/TagViewModel.kt
@@ -41,6 +41,7 @@ class TagViewModel @Inject constructor(
     fun deleteTag(tagId: Long) {
         CoroutineScope(Dispatchers.IO).launch {
             deleteTagUseCase(tagId)
+            getTagList()
         }
     }
 


### PR DESCRIPTION
Room DAO에서 return을 Flow에서 일반 데이터 형으로 반환한 이후
자동으로 업데이느 테이터를 observe할수 없기 떄문에 임의로 호출한다