### PR TITLE
[MIM-69] [FIXME] Background 갔다 foreground 오면 Bottom sheet들 다시 뜨는 문제

### DIFF
--- a/presentation/src/main/java/com/moon/morningismiracle/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/home/HomeFragment.kt
@@ -60,7 +60,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         }
     }
 
-    private fun getPlanData() {
+    fun getPlanData() {
         viewModel.getPlanList(DateInfo.today)
     }
 
@@ -86,13 +86,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     private fun showAddBottomSheet() {
         val addPlanThatDayBS = AddPlanBottomSheetDialogFragment.newInstance(CalendarDay.from(DateInfo.today))
         addPlanThatDayBS.show(
-            requireActivity().supportFragmentManager,
+            childFragmentManager,
             AddPlanBottomSheetDialogFragment.TAG
         )
-        requireActivity().supportFragmentManager.executePendingTransactions()
-        addPlanThatDayBS.dialog?.setOnDismissListener {
-            getPlanData()
-        }
     }
 
     private fun onSuccessClick(planId: Long, isSelect: Boolean) {

--- a/presentation/src/main/java/com/moon/morningismiracle/plan/AddPlanBottomSheetDialogFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/plan/AddPlanBottomSheetDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.moon.morningismiracle.plan
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,6 +17,7 @@ import com.moon.domain.model.PlanState
 import com.moon.domain.model.TagModel
 import com.moon.morningismiracle.R
 import com.moon.morningismiracle.databinding.BottomSheetAddPlanBinding
+import com.moon.morningismiracle.home.HomeFragment
 import com.moon.morningismiracle.tag.TagViewModel
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,6 +54,14 @@ class AddPlanBottomSheetDialogFragment : BottomSheetDialogFragment() {
         initView()
         tagViewModel.getTagList()
         setObserver()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        chooseDate?.let { date ->
+            (parentFragment as? HomeFragment)?.getPlanData()
+            (parentFragment as? PlanFragment)?.getDate(date)
+        }
     }
 
     private fun initView() {

--- a/presentation/src/main/java/com/moon/morningismiracle/plan/PlanFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/plan/PlanFragment.kt
@@ -31,7 +31,8 @@ class PlanFragment : BaseFragment<FragmentPlanBinding>() {
         super.onViewCreated(view, savedInstanceState)
 
         initView(DateInfo.today)
-        initPlanRecyclerView(DateInfo.today)
+        initPlanRecyclerView()
+        getDate(DateInfo.today)
         setObserve()
         setOnClick()
     }
@@ -63,13 +64,16 @@ class PlanFragment : BaseFragment<FragmentPlanBinding>() {
         }
     }
 
-    private fun initPlanRecyclerView(date: Date) {
+    private fun initPlanRecyclerView() {
         binding.calendarTabPlanList.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = planAdapter
             planAdapter.onDeleteBtn = ::onDeleteBtn
             itemAnimator = null
         }
+    }
+
+    fun getDate(date: Date) {
         planViewModel.getSelectDayPlanList(date)
     }
 
@@ -115,13 +119,9 @@ class PlanFragment : BaseFragment<FragmentPlanBinding>() {
     private fun showAddBottomSheet() {
         val addPlanThatDayBS = AddPlanBottomSheetDialogFragment.newInstance(selectedDateForAddPlan)
         addPlanThatDayBS.show(
-            requireActivity().supportFragmentManager,
+            childFragmentManager,
             AddPlanBottomSheetDialogFragment.TAG
         )
-        requireActivity().supportFragmentManager.executePendingTransactions()
-        addPlanThatDayBS.dialog?.setOnDismissListener {
-            planViewModel.getSelectDayPlanList(selectedDateForAddPlan.date)
-        }
     }
 
     private fun onDeleteBtn(item: PlanModel) {

--- a/presentation/src/main/java/com/moon/morningismiracle/tag/AddTagBottomSheetDialogFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/tag/AddTagBottomSheetDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.moon.morningismiracle.tag
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -54,6 +55,11 @@ class AddTagBottomSheetDialogFragment : BottomSheetDialogFragment() {
                 initViewAddMode()
             }
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        (parentFragment as? TagFragment)?.getData()
     }
 
     private fun initViewAddMode() {

--- a/presentation/src/main/java/com/moon/morningismiracle/tag/TagFragment.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/tag/TagFragment.kt
@@ -38,15 +38,11 @@ class TagFragment: BaseFragment<FragmentTagBinding>() {
 
         binding.addTagBtn.setOnClickListener {
             val addTagBottomSheet = AddTagBottomSheetDialogFragment.getInstance(false)
-            addTagBottomSheet.show(requireActivity().supportFragmentManager, AddTagBottomSheetDialogFragment.TAG)
-            requireActivity().supportFragmentManager.executePendingTransactions()
-            addTagBottomSheet.dialog?.setOnDismissListener {
-                getData()
-            }
+            addTagBottomSheet.show(childFragmentManager, AddTagBottomSheetDialogFragment.TAG)
         }
     }
 
-    private fun getData() {
+    fun getData() {
         tagViewModel.getTagList()
     }
 
@@ -73,12 +69,8 @@ class TagFragment: BaseFragment<FragmentTagBinding>() {
         val updateBottomSheetDialogFragment =
             AddTagBottomSheetDialogFragment.getInstance(true, tagModel)
         updateBottomSheetDialogFragment.show(
-            requireActivity().supportFragmentManager,
+            childFragmentManager,
             "${AddTagBottomSheetDialogFragment.TAG}${tagModel.tagId}"
         )
-        requireActivity().supportFragmentManager.executePendingTransactions()
-        updateBottomSheetDialogFragment.dialog?.setOnDismissListener {
-            getData()
-        }
     }
 }


### PR DESCRIPTION
Background 갔다 foreground 오면 Bottom sheet들 다시 뜨는 문제가 있었는데
원인은 Bottom Sheet에 Dismiss listener 동작을 위해 사용했던 executePendingTransactions() 문이 문제였다

공식 문서에도 setOnDismissListener를 사용하지말고 onDismis를 override해서 사용하라고 하는데..

Note: Don't call setOnCancelListener or setOnDismissListener on a BottomSheetDialogFragment, instead you can override onCancel(DialogInterface) or onDismiss(DialogInterface) if necessary.

이런경우 BottomSheetDialogFragment에서 (parentFragment as? TagFragment)? 이런 형변환하는 구문이 필요하고.. 여러 Fragment에서 사용하는경우 모두 처리를 해줘야해서 이걸 정말 피하고싶었지만.. 일단 문제를 해결하기위해 이렇게 사용하기로 했다.
추후에 버전업 하면 더 좋은 방향을 연구하기로 했다