### PR TITLE
[MIM-75] Dao function suspend로 일괄수정

### DIFF
--- a/data/src/main/java/com/moon/data/repo/PlanRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/data/repo/PlanRepositoryImpl.kt
@@ -5,8 +5,6 @@ import com.moon.data.mapper.PlanMapper
 import com.moon.domain.model.PlanModel
 import com.moon.domain.model.PlanState
 import com.moon.domain.repository.PlanRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.util.*
 import javax.inject.Inject
 
@@ -33,9 +31,7 @@ class PlanRepositoryImpl @Inject constructor(private val database: MIMRoomDataba
         database.planDao().setPlanStateBeforeToday(date)
     }
 
-    override fun getPlanListThatDate(date: Date): Flow<List<PlanModel>> {
-        return flow {
-            emit(PlanMapper.mapEntityToModelList(database.planDao().getPlanListThatDate(date)))
-        }
+    override suspend fun getPlanListThatDate(date: Date): List<PlanModel> {
+        return PlanMapper.mapEntityToModelList(database.planDao().getPlanListThatDate(date))
     }
 }

--- a/data/src/main/java/com/moon/data/repo/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/data/repo/StatisticsRepositoryImpl.kt
@@ -5,30 +5,23 @@ import com.moon.data.room.database.MIMRoomDatabase
 import com.moon.domain.model.StatisticsTotalModel
 import com.moon.domain.model.TagStatisticsModel
 import com.moon.domain.repository.StatisticsRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.util.*
 import javax.inject.Inject
 
 class StatisticsRepositoryImpl @Inject constructor(private val database: MIMRoomDatabase) :
     StatisticsRepository {
-    override fun getResultStateCount(startDate: Date, endDate: Date): Flow<StatisticsTotalModel> {
-        return flow {
-            emit(
-                StatisticsMapper.mapEntityToStatisticsTotalModel(
-                    database.statisticsDao().getResultStateCount(startDate, endDate)
-                )
-            )
-        }
+    override suspend fun getResultStateCount(startDate: Date, endDate: Date): StatisticsTotalModel {
+        return StatisticsMapper.mapEntityToStatisticsTotalModel(
+            database.statisticsDao().getResultStateCount(startDate, endDate)
+        )
     }
 
-    override fun getResultTagCount(startDate: Date, endDate: Date): Flow<List<TagStatisticsModel>> {
-        return flow {
-            emit(
-                StatisticsMapper.mapEntityListToTagStatisticsModelList(
-                    database.statisticsDao().getResultTagCount(startDate, endDate)
-                )
-            )
-        }
+    override suspend fun getResultTagCount(
+        startDate: Date,
+        endDate: Date
+    ): List<TagStatisticsModel> {
+        return StatisticsMapper.mapEntityListToTagStatisticsModelList(
+            database.statisticsDao().getResultTagCount(startDate, endDate)
+        )
     }
 }

--- a/data/src/main/java/com/moon/data/repo/TagRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/data/repo/TagRepositoryImpl.kt
@@ -2,11 +2,8 @@ package com.moon.data.repo
 
 import com.moon.data.mapper.TagMapper
 import com.moon.data.room.database.MIMRoomDatabase
-import com.moon.domain.DataResult
 import com.moon.domain.model.TagModel
 import com.moon.domain.repository.TagRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class TagRepositoryImpl @Inject constructor(private val database: MIMRoomDatabase) : TagRepository {
@@ -15,23 +12,21 @@ class TagRepositoryImpl @Inject constructor(private val database: MIMRoomDatabas
         database.tagDao().insert(TagMapper.modelToEntity(tagModel))
     }
 
-    override suspend fun deleteTag(tagId: Long): DataResult<Int> {
-        return DataResult.Success(database.tagDao().deleteTag(tagId))
+    override suspend fun deleteTag(tagId: Long) {
+        database.tagDao().deleteTag(tagId)
     }
 
-    override suspend fun updateTagColor(tagId: Long, tagColor: String): DataResult<Int> {
-        return DataResult.Success(database.tagDao().updateTagColor(tagId, tagColor))
+    override suspend fun updateTagColor(tagId: Long, tagColor: String) {
+        database.tagDao().updateTagColor(tagId, tagColor)
     }
 
-    override fun getTagList(): Flow<List<TagModel>> {
-        return flow {
-            database.tagDao().getTagList().let { list ->
-                val returnData: MutableList<TagModel> = mutableListOf()
-                list.map { item ->
-                    returnData.add(TagMapper.entityToModel(item))
-                }
-                emit(returnData)
+    override suspend fun getTagList(): List<TagModel> {
+        val returnData: MutableList<TagModel> = mutableListOf()
+        database.tagDao().getTagList().let { list ->
+            list.map { item ->
+                returnData.add(TagMapper.entityToModel(item))
             }
         }
+        return returnData
     }
 }

--- a/data/src/main/java/com/moon/data/room/dao/PlanDao.kt
+++ b/data/src/main/java/com/moon/data/room/dao/PlanDao.kt
@@ -11,7 +11,7 @@ interface PlanDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(plan: PlanEntity)
 
-    // 2. 계획 delete - TODO 상태가 waiting, later인것만 호출하도록 보장하기
+    // 2. 계획 delete
     @Delete
     suspend fun delete(plan: PlanEntity)
 
@@ -45,5 +45,5 @@ interface PlanDao {
         where plan_date = :date
     """
     )
-    fun getPlanListThatDate(date: Date): List<PlanWithTagData>
+    suspend fun getPlanListThatDate(date: Date): List<PlanWithTagData>
 }

--- a/data/src/main/java/com/moon/data/room/dao/StatisticsDao.kt
+++ b/data/src/main/java/com/moon/data/room/dao/StatisticsDao.kt
@@ -22,7 +22,7 @@ interface StatisticsDao {
         plan_date <= :endDate
     """
     )
-    fun getResultStateCount(startDate: Date, endDate: Date): ResultStateCountData
+    suspend fun getResultStateCount(startDate: Date, endDate: Date): ResultStateCountData
 
     // 2. 태그별 건수 조회
     @Query(
@@ -41,5 +41,5 @@ interface StatisticsDao {
         group by plan_tag_id;
     """
     )
-    fun getResultTagCount(startDate: Date, endDate: Date): List<ResultTagCountData>
+    suspend fun getResultTagCount(startDate: Date, endDate: Date): List<ResultTagCountData>
 }

--- a/data/src/main/java/com/moon/data/room/dao/TagDao.kt
+++ b/data/src/main/java/com/moon/data/room/dao/TagDao.kt
@@ -20,5 +20,5 @@ interface TagDao {
 
     // 4. 태그 조회
     @Query("select * from tag_table where tag_state= 1")
-    fun getTagList(): List<TagEntity>
+    suspend fun getTagList(): List<TagEntity>
 }

--- a/domain/src/main/java/com/moon/domain/DataResult.kt
+++ b/domain/src/main/java/com/moon/domain/DataResult.kt
@@ -1,8 +1,0 @@
-package com.moon.domain
-
-import java.lang.Exception
-
-sealed class DataResult<out T> {
-    data class Success<out T>(val data: T): DataResult<T>()
-    data class Error(val exception: Exception): DataResult<Nothing>()
-}

--- a/domain/src/main/java/com/moon/domain/repository/PlanRepository.kt
+++ b/domain/src/main/java/com/moon/domain/repository/PlanRepository.kt
@@ -2,7 +2,6 @@ package com.moon.domain.repository
 
 import com.moon.domain.model.PlanModel
 import com.moon.domain.model.PlanState
-import kotlinx.coroutines.flow.Flow
 import java.util.*
 
 interface PlanRepository {
@@ -11,5 +10,5 @@ interface PlanRepository {
     suspend fun setPlanState(planId: Long, newState: PlanState)
     suspend fun setPlanStateBeforeToday(date: Date)
     suspend fun setPlanDelayOneDayUseCase(planId: Long, newDate: Date)
-    fun getPlanListThatDate(date: Date): Flow<List<PlanModel>>
+    suspend fun getPlanListThatDate(date: Date): List<PlanModel>
 }

--- a/domain/src/main/java/com/moon/domain/repository/StatisticsRepository.kt
+++ b/domain/src/main/java/com/moon/domain/repository/StatisticsRepository.kt
@@ -2,10 +2,9 @@ package com.moon.domain.repository
 
 import com.moon.domain.model.StatisticsTotalModel
 import com.moon.domain.model.TagStatisticsModel
-import kotlinx.coroutines.flow.Flow
 import java.util.*
 
 interface StatisticsRepository {
-    fun getResultStateCount(startDate: Date, endDate: Date): Flow<StatisticsTotalModel>
-    fun getResultTagCount(startDate: Date, endDate: Date): Flow<List<TagStatisticsModel>>
+    suspend fun getResultStateCount(startDate: Date, endDate: Date): StatisticsTotalModel
+    suspend fun getResultTagCount(startDate: Date, endDate: Date): List<TagStatisticsModel>
 }

--- a/domain/src/main/java/com/moon/domain/repository/TagRepository.kt
+++ b/domain/src/main/java/com/moon/domain/repository/TagRepository.kt
@@ -1,12 +1,10 @@
 package com.moon.domain.repository
 
-import com.moon.domain.DataResult
 import com.moon.domain.model.TagModel
-import kotlinx.coroutines.flow.Flow
 
 interface TagRepository {
     suspend fun addTag(tagModel: TagModel)
-    suspend fun deleteTag(tagId: Long): DataResult<Int>
-    suspend fun updateTagColor(tagId: Long, tagColor: String): DataResult<Int>
-    fun getTagList(): Flow<List<TagModel>>
+    suspend fun deleteTag(tagId: Long)
+    suspend fun updateTagColor(tagId: Long, tagColor: String)
+    suspend fun getTagList(): List<TagModel>
 }

--- a/domain/src/main/java/com/moon/domain/usecase/DeleteTagUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/DeleteTagUseCase.kt
@@ -1,11 +1,10 @@
 package com.moon.domain.usecase
 
-import com.moon.domain.DataResult
 import com.moon.domain.repository.TagRepository
 import javax.inject.Inject
 
 class DeleteTagUseCase @Inject constructor(private val repository: TagRepository) {
-    suspend operator fun invoke(tagId: Long): DataResult<Int> {
+    suspend operator fun invoke(tagId: Long) {
         return repository.deleteTag(tagId)
     }
 }

--- a/domain/src/main/java/com/moon/domain/usecase/GetPlanListUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/GetPlanListUseCase.kt
@@ -2,12 +2,11 @@ package com.moon.domain.usecase
 
 import com.moon.domain.model.PlanModel
 import com.moon.domain.repository.PlanRepository
-import kotlinx.coroutines.flow.Flow
 import java.util.*
 import javax.inject.Inject
 
 class GetPlanListUseCase @Inject constructor(private val repository: PlanRepository) {
-    operator fun invoke(date: Date): Flow<List<PlanModel>> {
+    suspend operator fun invoke(date: Date): List<PlanModel> {
         return repository.getPlanListThatDate(date)
     }
 }

--- a/domain/src/main/java/com/moon/domain/usecase/GetResultStateCountUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/GetResultStateCountUseCase.kt
@@ -2,12 +2,11 @@ package com.moon.domain.usecase
 
 import com.moon.domain.model.StatisticsTotalModel
 import com.moon.domain.repository.StatisticsRepository
-import kotlinx.coroutines.flow.Flow
 import java.util.*
 import javax.inject.Inject
 
 class GetResultStateCountUseCase @Inject constructor(private val repository: StatisticsRepository) {
-    operator fun invoke(startDate: Date, endDate: Date): Flow<StatisticsTotalModel> {
+    suspend operator fun invoke(startDate: Date, endDate: Date): StatisticsTotalModel {
         return repository.getResultStateCount(startDate, endDate)
     }
 }

--- a/domain/src/main/java/com/moon/domain/usecase/GetResultTagCountUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/GetResultTagCountUseCase.kt
@@ -2,12 +2,11 @@ package com.moon.domain.usecase
 
 import com.moon.domain.model.TagStatisticsModel
 import com.moon.domain.repository.StatisticsRepository
-import kotlinx.coroutines.flow.Flow
 import java.util.*
 import javax.inject.Inject
 
 class GetResultTagCountUseCase @Inject constructor(private val repository: StatisticsRepository) {
-    operator fun invoke(startDate: Date, endDate: Date): Flow<List<TagStatisticsModel>> {
+    suspend operator fun invoke(startDate: Date, endDate: Date): List<TagStatisticsModel> {
         return repository.getResultTagCount(startDate, endDate)
     }
 }

--- a/domain/src/main/java/com/moon/domain/usecase/GetTagListUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/GetTagListUseCase.kt
@@ -2,11 +2,10 @@ package com.moon.domain.usecase
 
 import com.moon.domain.model.TagModel
 import com.moon.domain.repository.TagRepository
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetTagListUseCase @Inject constructor(private val repository: TagRepository) {
-    operator fun invoke(): Flow<List<TagModel>> {
+    suspend operator fun invoke(): List<TagModel> {
         return repository.getTagList()
     }
 }

--- a/domain/src/main/java/com/moon/domain/usecase/UpdateTagColorUseCase.kt
+++ b/domain/src/main/java/com/moon/domain/usecase/UpdateTagColorUseCase.kt
@@ -1,11 +1,10 @@
 package com.moon.domain.usecase
 
-import com.moon.domain.DataResult
 import com.moon.domain.repository.TagRepository
 import javax.inject.Inject
 
 class UpdateTagColorUseCase @Inject constructor(private val repository: TagRepository) {
-    suspend operator fun invoke(tagId: Long, color: String): DataResult<Int> {
+    suspend operator fun invoke(tagId: Long, color: String) {
         return repository.updateTagColor(tagId, color)
     }
 }

--- a/presentation/src/main/java/com/moon/morningismiracle/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/home/HomeViewModel.kt
@@ -26,16 +26,14 @@ class HomeViewModel @Inject constructor(
     private val setPlanDelayOneDayUseCase: SetPlanDelayOneDayUseCase,
     private val setPlanStateBeforeTodayUseCase: SetPlanStateBeforeTodayUseCase,
     private val dateStore: DataStore,
-): ViewModel() {
+) : ViewModel() {
 
     private val _planDataList = MutableStateFlow<List<PlanModel>>(emptyList())
     val planDataList: StateFlow<List<PlanModel>> = _planDataList
 
     fun getPlanList(date: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getPlanListUseCase(date = date).collect { list ->
-                _planDataList.value = list
-            }
+            _planDataList.value = getPlanListUseCase(date = date)
         }
     }
 

--- a/presentation/src/main/java/com/moon/morningismiracle/plan/PlanViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/plan/PlanViewModel.kt
@@ -39,9 +39,7 @@ class PlanViewModel @Inject constructor(
 
     fun getSelectDayPlanList(date: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getPlanListUseCase(date = date).collect { list ->
-                _selectDayPlanDataList.value = list
-            }
+            _selectDayPlanDataList.value = getPlanListUseCase(date = date)
         }
     }
 }

--- a/presentation/src/main/java/com/moon/morningismiracle/statistics/StatisticsViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/statistics/StatisticsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
@@ -36,33 +35,25 @@ class StatisticsViewModel @Inject constructor(
 
     fun getResultStateCountForWeek(startDate: Date, endDate: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getResultStateCountUseCase(startDate, endDate).collect { dataResult ->
-                _weekStateCount.value = dataResult
-            }
+            _weekStateCount.value = getResultStateCountUseCase(startDate, endDate)
         }
     }
 
     fun getResultStateCountForMonth(startDate: Date, endDate: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getResultStateCountUseCase(startDate, endDate).collect { dataResult ->
-                _monthStateCount.value = dataResult
-            }
+            _monthStateCount.value = getResultStateCountUseCase(startDate, endDate)
         }
     }
 
     fun getResultTagCountForWeek(startDate: Date, endDate: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getResultTagCountUseCase(startDate, endDate).collect { dataResult ->
-                _tagStatisticsWeekList.value = dataResult
-            }
+            _tagStatisticsWeekList.value = getResultTagCountUseCase(startDate, endDate)
         }
     }
 
     fun getResultTagCountForMonth(startDate: Date, endDate: Date) {
         CoroutineScope(Dispatchers.IO).launch {
-            getResultTagCountUseCase(startDate, endDate).collect { dataResult ->
-                _tagStatisticsMonthList.value = dataResult
-            }
+            _tagStatisticsMonthList.value = getResultTagCountUseCase(startDate, endDate)
         }
     }
 }

--- a/presentation/src/main/java/com/moon/morningismiracle/tag/TagViewModel.kt
+++ b/presentation/src/main/java/com/moon/morningismiracle/tag/TagViewModel.kt
@@ -26,9 +26,7 @@ class TagViewModel @Inject constructor(
 
     fun getTagList() {
         CoroutineScope(Dispatchers.IO).launch {
-            getTagListUseCase().collect { dataResult ->
-                _tagDataList.value = dataResult
-            }
+            _tagDataList.value = getTagListUseCase()
         }
     }
 


### PR DESCRIPTION
Dao function을 suspend 로 일괄 수정하고,
repository에서 Flow 빌더로 생성하던것을 suspend function return value로 수정합니다.
Flow는 multiple value를 순차적으로 전송한다는면에서 suspend와 차이가 있다고 볼수 있는데
어차피 현재 DAO는 조회가 필요할때 한번씩 호촐하고, 한번씩 value를 받고있기 때문에 Flow를 생성할 필요가 없을듯 하다